### PR TITLE
Bugfix

### DIFF
--- a/src/pdf-invoice/test.vala
+++ b/src/pdf-invoice/test.vala
@@ -13,7 +13,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-public static int main(string args[]) {
+public static int main(string[] args) {
 	PDFInvoice invoice;
 
 	try {

--- a/src/pdf-stock/test.vala
+++ b/src/pdf-stock/test.vala
@@ -13,7 +13,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-public static int main(string args[]) {
+public static int main(string[] args) {
 	try {
 		PDFStock stock = Bus.get_proxy_sync(BusType.SYSTEM, "io.mainframe.shopsystem.StockPDF", "/io/mainframe/shopsystem/stockpdf");
 		var pdfdata = stock.generate(true);


### PR DESCRIPTION
Code didn't compile.
Brackets were in wrong position.

../src/pdf-invoice/test.vala:16.37-16.37: error: syntax error, invalid array parameter declaration
public static int main(string args[]) {
                                    ^
